### PR TITLE
Fluentify space

### DIFF
--- a/Space.js
+++ b/Space.js
@@ -13,11 +13,11 @@ module.exports = function Space(key, reporters, errback) {
   }
 
   this.value = function (val) {
-      forEachReporter(reporter => reporter.value(key, val));
+    forEachReporter(reporter => reporter.value(key, val));
   };
 
   this.increment = function (val = 1) {
-      forEachReporter(reporter => reporter.increment(key, val));
+    forEachReporter(reporter => reporter.increment(key, val));
   };
 
   this.meter = function(func) {
@@ -46,6 +46,10 @@ module.exports = function Space(key, reporters, errback) {
         return result;
       }
     };
+  };
+
+  this.space = function(nextKey) {
+    return new Space(`${key}.${nextKey}`, reporters, errback);
   };
 
   function report(key, start, finish) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Metrics reporting framework for reporting data point information to aggregators (like Graphite)",
   "license": "MIT",
   "keywords": ["metrics", "graphite", "performance"],
-  "version": "0.2.3",
+  "version": "0.3.3",
   "repository" :
   {
     "type" : "git",

--- a/test/space-tests.js
+++ b/test/space-tests.js
@@ -210,6 +210,21 @@ describe('Space', function() {
       });
     });
   });
+
+    describe('space', function () {
+      it('should create a report with the concatenated key', function() {
+        var reports = [];
+        var reporter = new InMemoryReporter(reports);
+        var metrics = new Metrics([ reporter ]);
+        var func = getSyncFunc(500);
+        var wrappedFunc = metrics.space('SYW').space('Adder').space('Foo').space('Bar').meter(func);
+
+        wrappedFunc(1, 1);
+        var report = reports[reports.length-1];
+
+        assert.equal(report.key, 'SYW.Adder.Foo.Bar');
+      });
+    });
 });
 
 function getAsyncFunc(duration) {


### PR DESCRIPTION
Added the ability to use the following syntax:

```js
metrics.space('SYW').space('Adder').space('Foo').space('Bar').meter(func);
```
